### PR TITLE
adding conditional to ga.js load

### DIFF
--- a/analytics.coffee
+++ b/analytics.coffee
@@ -72,13 +72,13 @@ upon = (type, selector, func) ->
         del = [window]
     else if selector is document
         del = [document]
-    else 
+    else
         try
             del = document.querySelectorAll selector
         catch e
             del = ''
 
-    for sel in del 
+    for sel in del
         if sel.addEventListener
             sel.addEventListener type, (e) ->
                 func.call(e.target, e)
@@ -191,13 +191,14 @@ init = (options) ->
       "inpage_linkid"
       pluginUrl
     ]
-    
+
     ##################
     # Load the GA script now so that setup items like _setAccount, etc. are in the queue
     # and so membership event listeners are in place. Ideally these would be in the pre-_trackPageview
-    # queue, but it's all asnyc, so w'll smoke 'em if we've got 'em. Otherwise we'll wait till it fires.
+    # queue, but it's all asnyc. Otherwise we'll wait till it fires.
     ##################
-    addScript "#{if isHTTPS then "https://ssl" else "http://www"}.google-analytics.com/ga.js"
+    sLoaded = (typeof window.ga !== "undefined" && window.ga !== null)
+    if !sLoaded then addScript "#{if isHTTPS then "https://ssl" else "http://www"}.google-analytics.com/ga.js"
 
     ##################
     # Log Link clicks
@@ -224,7 +225,7 @@ init = (options) ->
     lastPlaybackReportTime = playbackReportTimes[playbackReportTimes.length - 1]
     hasStarted = false
 
-    ## TODO 
+    ## TODO
     # add generic tracking events back in
     # #
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "homepage": "https://github.com/natgeo/modules-analytics",
   "authors": [
     "NGS"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Module for setting up Analytics on NGS projects",
   "main": "analytics.min.js",
   "scripts": {
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "matchdep": "~0.1.1",
-    "grunt-contrib-watch": "~0.4.4",
-    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-bump-build-git": "^1.0.0",
     "grunt-coffeelint": "0.0.7",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-uglify": "~0.2.5",
-    "grunt-bump-build-git": "~1.0.0"
+    "grunt-contrib-coffee": "^0.7.0",
+    "grunt-contrib-uglify": "^0.2.7",
+    "grunt-contrib-watch": "^0.4.4",
+    "matchdep": "^0.1.2"
   }
 }


### PR DESCRIPTION
Some sites are loading multiple instances of ga.js from this module, which is also loaded more than once. This should stop that by checking the global instance for _gaq.